### PR TITLE
Indexed vertices API

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -21,12 +21,17 @@ function areaTest(filename, expectedDeviation) {
     test(filename, function (t) {
 
         var data = JSON.parse(fs.readFileSync(__dirname + '/fixtures/' + filename + '.json')),
-            triangles = earcut(data),
+            result = earcut(data),
+            vertices = result.vertices,
+            indices = result.indices,
             expectedArea = polygonArea(data),
             area = 0;
 
-        for (var i = 0; i < triangles.length; i += 3) {
-            area += triangleArea(triangles[i], triangles[i + 1], triangles[i + 2]);
+        for (var i = 0; i < indices.length; i += 3) {
+            area += triangleArea(
+                [vertices[indices[i]], vertices[indices[i] + 1]],
+                [vertices[indices[i + 1]], vertices[indices[i + 1] + 1]],
+                [vertices[indices[i + 2]], vertices[indices[i + 2] + 1]]);
         }
 
         var deviation = expectedArea === 0 && area === 0 ? 0 : Math.abs(area - expectedArea) / expectedArea;

--- a/viz/index.html
+++ b/viz/index.html
@@ -60,9 +60,15 @@
 
         console.time('earcut');
         // for (var i = 0; i < 1000; i++) {
-        var triangles = earcut(testPoints);
+        var result = earcut(testPoints);
         // }
         console.timeEnd('earcut');
+
+        var triangles = [];
+        for (var i = 0; i < result.indices.length; i++) {
+        	var index = result.indices[i];
+        	triangles.push([result.vertices[index], result.vertices[index + 1]]);
+        }
 
         ctx.lineJoin = 'round';
 


### PR DESCRIPTION
Changes the API to return indexed vertices. Closes #4. 

We need to evaluate the approach in the real world first before making a change like this because it comes with a performance cost of ~15-20%.

This also breaks the 3D vertices use cases, we need to think about it API-wise.