### PR TITLE
Add repository field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,5 +22,9 @@
     "tape": "^3.5.0",
     "uglify-js": "^2.4.17",
     "watchify": "^2.4.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/mapbox/earcut.git"
   }
 }


### PR DESCRIPTION
If we install earcut as a dependency, npm writes the following message:
`npm WARN package.json earcut@1.4.2 No repository field.`