### PR TITLE
always pick the same connection nodes

### DIFF
--- a/src/earcut.js
+++ b/src/earcut.js
@@ -271,7 +271,10 @@ function eliminateHoles(data, holeIndices, outerNode, dim) {
 }
 
 function compareX(a, b) {
-    return a.x - b.x;
+    var c = a.x - b.x;
+    if (c !== 0) return c;
+
+    return a.y - b.y;
 }
 
 // find a bridge between vertices that connects hole with an outer ring and and link it
@@ -444,7 +447,11 @@ function getLeftmost(start) {
     var p = start,
         leftmost = start;
     do {
-        if (p.x < leftmost.x) leftmost = p;
+        if (p.x < leftmost.x) {
+            leftmost = p;
+        } else if (p.x === leftmost.x && p.y < leftmost.y) {
+            leftmost = p;
+        }
         p = p.next;
     } while (p !== start);
 


### PR DESCRIPTION
- pick nodes for bridges and holes in the same order independent
of the ring-order or point-in-ring-position.

@mourner can you check this for regressions? I saw that just changing the order of rings effected  whether the triangulation of the simplified polygon in #56 succeeded. So this should make the results at least more consistent - and triangulates the simplified polygon.