### PR TITLE
Improve topology (draft)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Some benchmarks using Node 0.12:
 
 (ops/sec)         | pts  | earcut    | libtess  | poly2tri | pnltri    | polyk
 ------------------| ---- | --------- | -------- | -------- | --------- | ------
-OSM building      | 15   | _892,485_ | _50,640_ | _61,501_ | _122,966_ | _175,570_
+OSM building      | 15   | _976,667_ | _50,640_ | _61,501_ | _122,966_ | _175,570_
 dude shape        | 94   | _47,456_  | _10,339_ | _8,784_  | _11,172_  | _13,557_
 holed dude shape  | 104  | _38,357_  | _8,883_  | _7,494_  | _2,130_   | n/a
 complex OSM water | 2523 | _701_     | _77.54_  | failure  | failure   | n/a

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ Some benchmarks using Node 0.12:
 
 (ops/sec)         | pts  | earcut    | libtess  | poly2tri | pnltri    | polyk
 ------------------| ---- | --------- | -------- | -------- | --------- | ------
-OSM building      | 15   | _827,648_ | _50,640_ | _61,501_ | _122,966_ | _175,570_
-dude shape        | 94   | _44,800_  | _10,339_ | _8,784_  | _11,172_  | _13,557_
-holed dude shape  | 104  | _36,390_  | _8,883_  | _7,494_  | _2,130_   | n/a
-complex OSM water | 2523 | _577_     | _77.54_  | failure  | failure   | n/a
+OSM building      | 15   | _803,478_ | _50,640_ | _61,501_ | _122,966_ | _175,570_
+dude shape        | 94   | _42,703_  | _10,339_ | _8,784_  | _11,172_  | _13,557_
+holed dude shape  | 104  | _37,532_  | _8,883_  | _7,494_  | _2,130_   | n/a
+complex OSM water | 2523 | _686_     | _77.54_  | failure  | failure   | n/a
 huge OSM water    | 5667 | _95_      | _29.30_  | failure  | failure   | n/a
 
 The original use case it was created for is [Mapbox GL](https://www.mapbox.com/mapbox-gl), WebGL-based interactive maps.

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ Some benchmarks using Node 0.12:
 (ops/sec)         | pts  | earcut    | libtess  | poly2tri | pnltri    | polyk
 ------------------| ---- | --------- | -------- | -------- | --------- | ------
 OSM building      | 15   | _827,648_ | _50,640_ | _61,501_ | _122,966_ | _175,570_
-dude shape        | 94   | _43,840_  | _10,339_ | _8,784_  | _11,172_  | _13,557_
-holed dude shape  | 104  | _36,009_  | _8,883_  | _7,494_  | _2,130_   | n/a
-complex OSM water | 2523 | _567_     | _77.54_  | failure  | failure   | n/a
+dude shape        | 94   | _44,800_  | _10,339_ | _8,784_  | _11,172_  | _13,557_
+holed dude shape  | 104  | _36,390_  | _8,883_  | _7,494_  | _2,130_   | n/a
+complex OSM water | 2523 | _577_     | _77.54_  | failure  | failure   | n/a
 huge OSM water    | 5667 | _95_      | _29.30_  | failure  | failure   | n/a
 
 The original use case it was created for is [Mapbox GL](https://www.mapbox.com/mapbox-gl), WebGL-based interactive maps.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Some benchmarks using Node 0.12:
 ------------------| ---- | --------- | -------- | -------- | --------- | ------
 OSM building      | 15   | _827,648_ | _50,640_ | _61,501_ | _122,966_ | _175,570_
 dude shape        | 94   | _43,840_  | _10,339_ | _8,784_  | _11,172_  | _13,557_
-holed dude shape  | 104  | _28,319_  | _8,883_  | _7,494_  | _2,130_   | n/a
+holed dude shape  | 104  | _36,009_  | _8,883_  | _7,494_  | _2,130_   | n/a
 complex OSM water | 2523 | _567_     | _77.54_  | failure  | failure   | n/a
 huge OSM water    | 5667 | _95_      | _29.30_  | failure  | failure   | n/a
 

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ Some benchmarks using Node 0.12:
 
 (ops/sec)         | pts  | earcut    | libtess  | poly2tri | pnltri    | polyk
 ------------------| ---- | --------- | -------- | -------- | --------- | ------
-OSM building      | 15   | _803,478_ | _50,640_ | _61,501_ | _122,966_ | _175,570_
-dude shape        | 94   | _42,703_  | _10,339_ | _8,784_  | _11,172_  | _13,557_
-holed dude shape  | 104  | _37,532_  | _8,883_  | _7,494_  | _2,130_   | n/a
-complex OSM water | 2523 | _686_     | _77.54_  | failure  | failure   | n/a
+OSM building      | 15   | _892,485_ | _50,640_ | _61,501_ | _122,966_ | _175,570_
+dude shape        | 94   | _47,456_  | _10,339_ | _8,784_  | _11,172_  | _13,557_
+holed dude shape  | 104  | _38,357_  | _8,883_  | _7,494_  | _2,130_   | n/a
+complex OSM water | 2523 | _701_     | _77.54_  | failure  | failure   | n/a
 huge OSM water    | 5667 | _95_      | _29.30_  | failure  | failure   | n/a
 
 The original use case it was created for is [Mapbox GL](https://www.mapbox.com/mapbox-gl), WebGL-based interactive maps.

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ Some benchmarks using Node 0.12:
 
 (ops/sec)         | pts  | earcut    | libtess  | poly2tri | pnltri    | polyk
 ------------------| ---- | --------- | -------- | -------- | --------- | ------
-OSM building      | 15   | _795,935_ | _50,640_ | _61,501_ | _122,966_ | _175,570_
-dude shape        | 94   | _35,658_  | _10,339_ | _8,784_  | _11,172_  | _13,557_
+OSM building      | 15   | _827,648_ | _50,640_ | _61,501_ | _122,966_ | _175,570_
+dude shape        | 94   | _43,840_  | _10,339_ | _8,784_  | _11,172_  | _13,557_
 holed dude shape  | 104  | _28,319_  | _8,883_  | _7,494_  | _2,130_   | n/a
-complex OSM water | 2523 | _543_     | _77.54_  | failure  | failure   | n/a
+complex OSM water | 2523 | _567_     | _77.54_  | failure  | failure   | n/a
 huge OSM water    | 5667 | _95_      | _29.30_  | failure  | failure   | n/a
 
 The original use case it was created for is [Mapbox GL](https://www.mapbox.com/mapbox-gl), WebGL-based interactive maps.

--- a/src/earcut.js
+++ b/src/earcut.js
@@ -470,8 +470,8 @@ function intersects(p1, q1, p2, q2) {
     if ((equals(p1, q1) && equals(p2, q2)) ||
         (equals(p1, q2) && equals(p2, q1))) return true;
 
-    return area(p1, q1, p2) * area(p1, q1, q2) < 0 &&
-           area(p2, q2, p1) * area(p2, q2, q1) < 0;
+    return area(p1, q1, p2) * area(p1, q1, q2) <= 0 &&
+           area(p2, q2, p1) * area(p2, q2, q1) <= 0;
 }
 
 // check if a polygon diagonal intersects any polygon segments

--- a/src/earcut.js
+++ b/src/earcut.js
@@ -152,8 +152,8 @@ function isEar(ear) {
         first = ear.prev;
 
     while (p !== first) {
-        if (area(p.prev, p, p.next) >= 0 &&
-            pointInTriangle(ax, ay, bx, by, cx, cy, p.x, p.y)) {
+        if (pointInTriangle(ax, ay, bx, by, cx, cy, p.x, p.y) &&
+            area(p.prev, p, p.next) >= 0) {
             return false;
         }
         p = p.next;

--- a/src/earcut.js
+++ b/src/earcut.js
@@ -499,7 +499,7 @@ function middleInside(a, b) {
         px = (a.x + b.x) / 2,
         py = (a.y + b.y) / 2;
     do {
-        if (((p.y > py) !== (p.next.y > py)) && p.next.y !== p.y &&
+        if (p.next.y !== p.y && ((p.y > py) !== (p.next.y > py)) &&
                 (px < (p.next.x - p.x) * (py - p.y) / (p.next.y - p.y) + p.x))
             inside = !inside;
         p = p.next;

--- a/src/earcut.js
+++ b/src/earcut.js
@@ -92,12 +92,14 @@ function earcutLinked(ear, triangles, dim, minX, minY, size, pass) {
     var stop = ear,
         prev, next;
 
+    var isEarCached = size ? isEarHashed : isEar;
+
     // iterate through ears, slicing them one by one
     while (ear.prev !== ear.next) {
         prev = ear.prev;
         next = ear.next;
 
-        if (size ? isEarHashed(ear, minX, minY, size) : isEar(ear)) {
+        if (isEarCached(ear, minX, minY, size)) {
             // cut off the triangle
             triangles.push(prev.i / dim);
             triangles.push(ear.i / dim);

--- a/src/earcut.js
+++ b/src/earcut.js
@@ -151,14 +151,23 @@ function isEar(ear) {
     var ax = a.x, ay = a.y,
         bx = b.x, by = b.y,
         cx = c.x, cy = c.y,
+
         ca = cx * ay - ax * cy,
         ab = ax * by - bx * ay,
         bc = bx * cy - cx * by,
+
+        cax = cx - ax,
+        cay = cy - ay,
+        abx = ax - bx,
+        aby = ay - by,
+        bcx = bx - cx,
+        bcy = by - cy,
+
         first = ear.prev;
 
     while (p !== first) {
         if (area(p.prev, p, p.next) >= 0 &&
-            pointInTriangleLoop(ca, ab, bc, ax, ay, bx, by, cx, cy, p.x, p.y)) {
+            pointInTriangleLoop(ca, ab, bc, cax, cay, abx, aby, bcx, bcy, p.x, p.y)) {
             return false;
         }
         p = p.next;
@@ -187,9 +196,18 @@ function isEarHashed(ear, minX, minY, size) {
     var ax = a.x, ay = a.y,
         bx = b.x, by = b.y,
         cx = c.x, cy = c.y,
+
         ca = cx * ay - ax * cy,
         ab = ax * by - bx * ay,
         bc = bx * cy - cx * by,
+
+        cax = cx - ax,
+        cay = cy - ay,
+        abx = ax - bx,
+        aby = ay - by,
+        bcx = bx - cx,
+        bcy = by - cy,
+
         first = ear.prev,
         last  = ear.next;
 
@@ -198,7 +216,7 @@ function isEarHashed(ear, minX, minY, size) {
 
     while (p && p.z <= maxZ) {
         if (p !== first && p !== last && area(p.prev, p, p.next) >= 0 &&
-            pointInTriangleLoop(ca, ab, bc, ax, ay, bx, by, cx, cy, p.x, p.y)) {
+            pointInTriangleLoop(ca, ab, bc, cax, cay, abx, aby, bcx, bcy, p.x, p.y)) {
             return false;
         }
 
@@ -210,7 +228,7 @@ function isEarHashed(ear, minX, minY, size) {
 
     while (p && p.z >= minZ) {
         if (p !== first && p !== last && area(p.prev, p, p.next) >= 0 &&
-            pointInTriangleLoop(ca, ab, bc, ax, ay, bx, by, cx, cy, p.x, p.y)) {
+            pointInTriangleLoop(ca, ab, bc, cax, cay, abx, aby, bcx, bcy, p.x, p.y)) {
             return false;
         }
 
@@ -274,11 +292,12 @@ function splitEarcut(start, triangles, dim, minX, minY, size) {
 // link every hole into the outer loop, producing a single-ring polygon without holes
 function eliminateHoles(data, holeIndices, outerNode, dim) {
     var queue = [],
-        i, len, start, end, list;
+        i, len, start, end, list,
+        dataLen = data.length;
 
     for (i = 0, len = holeIndices.length; i < len; i++) {
         start = holeIndices[i] * dim;
-        end = i < len - 1 ? holeIndices[i + 1] * dim : data.length;
+        end = i < len - 1 ? holeIndices[i + 1] * dim : dataLen;
         list = linkedList(data, start, end, dim, false);
         if (list === list.next) list.steiner = true;
         queue.push(getLeftmost(list));
@@ -349,18 +368,25 @@ function findHoleBridge(hole, outerNode) {
 
     p = m.next;
 
-    var ax = hy < my ? hx : qx;
-    var cx = hy < my ? qx : hx;
-
-    var ay = hy, bx = mx,
+    var ax = hy < my ? hx : qx,
+        cx = hy < my ? qx : hx,
+        ay = hy, bx = mx,
         by = my, cy = hy,
+
         ca = cx * ay - ax * cy,
         ab = ax * by - bx * ay,
-        bc = bx * cy - cx * by;
+        bc = bx * cy - cx * by,
+
+        cax = cx - ax,
+        cay = cy - ay,
+        abx = ax - bx,
+        aby = ay - by,
+        bcx = bx - cx,
+        bcy = by - cy;
 
     while (p !== stop) {
         if (hx >= p.x && p.x >= mx && hx !== p.x &&
-            pointInTriangleLoop(ca, ab, bc, ax, ay, bx, by, cx, cy, p.x, p.y)) {
+            pointInTriangleLoop(ca, ab, bc, cax, cay, abx, aby, bcx, bcy, p.x, p.y)) {
 
             tan = Math.abs(hy - p.y) / (hx - p.x); // tangential
 
@@ -445,6 +471,7 @@ function sortLinked(list) {
     return list;
 }
 
+
 // z-order of a point given coords and size of the data bounding box
 function zOrder(x, y, minX, minY, size) {
     // coords are transformed into non-negative 15-bit integer range
@@ -484,10 +511,10 @@ function getLeftmost(start) {
 }*/
 
 // check if a point lies within a convex triangle
-function pointInTriangleLoop(ca, ab, bc, ax, ay, bx, by, cx, cy, px, py) {
-    return ca + (cy - ay) * px - (cx - ax) * py >= 0 &&
-           ab + (ay - by) * px - (ax - bx) * py >= 0 &&
-           bc + (by - cy) * px - (bx - cx) * py >= 0;
+function pointInTriangleLoop(ca, ab, bc, cax, cay, abx, aby, bcx, bcy, px, py) {
+    return cay * px + ca - cax * py >= 0 &&
+           aby * px + ab - abx * py >= 0 &&
+           bcy * px + bc - bcx * py >= 0;
 }
 
 // check if a diagonal between two polygon nodes is valid (lies in polygon interior)

--- a/src/earcut.js
+++ b/src/earcut.js
@@ -560,11 +560,13 @@ function locallyInside(a, b) {
 function middleInside(a, b) {
     var p = a,
         inside = false,
-        px = (a.x + b.x) / 2,
-        py = (a.y + b.y) / 2;
+        px = (a.x + b.x) * 0.5,
+        py = (a.y + b.y) * 0.5;
     do {
-        if (p.next.y !== p.y && ((p.y > py) !== (p.next.y > py)) &&
-                (px < (p.next.x - p.x) * (py - p.y) / (p.next.y - p.y) + p.x))
+        var dy  = p.y - py;
+        var dny = p.next.y - p.y;
+        if (dny !== 0 && (dy > 0) !== (p.next.y - py > 0) &&
+            (px < (p.x - p.next.x) * dy / dny + p.x))
             inside = !inside;
         p = p.next;
     } while (p !== a);

--- a/src/earcut.js
+++ b/src/earcut.js
@@ -100,7 +100,7 @@ function earcutLinked(ear, triangles, dim, minX, minY, size, pass) {
         prev = ear.prev;
         next = ear.next;
 
-        if (isEarCached(ear, minX, minY, size)) {
+        if (isEarCached(ear, minX, minY, size, (pass | 0) === 0)) {
             // cut off the triangle
             triangles.push(prev.i * invDim);
             triangles.push(ear.i  * invDim);
@@ -162,7 +162,16 @@ function isEar(ear) {
     return true;
 }
 
-function isEarHashed(ear, minX, minY, size) {
+function aspect(a, b, c) {
+    var minX = a.x < b.x ? (a.x < c.x ? a.x : c.x) : (b.x < c.x ? b.x : c.x),
+        minY = a.y < b.y ? (a.y < c.y ? a.y : c.y) : (b.y < c.y ? b.y : c.y),
+        maxX = a.x > b.x ? (a.x > c.x ? a.x : c.x) : (b.x > c.x ? b.x : c.x),
+        maxY = a.y > b.y ? (a.y > c.y ? a.y : c.y) : (b.y > c.y ? b.y : c.y);
+
+    return (maxY - minY) / (maxX - minX);
+}
+
+function isEarHashed(ear, minX, minY, size, checkAspect) {
     var a = ear.prev,
         b = ear,
         c = ear.next;
@@ -202,6 +211,7 @@ function isEarHashed(ear, minX, minY, size) {
 
     while (p && p.z >= minZ) {
         if (p !== first && p !== last &&
+            (checkAspect ? Math.abs(aspect(p.prev, p, p.next) - 1) >= 0.2 : true) &&
             pointInTriangleLoop(ca, ab, bc, cax, cay, abx, aby, bcx, bcy, p.x, p.y) &&
             area(p.prev, p, p.next) >= 0) {
             return false;
@@ -215,6 +225,7 @@ function isEarHashed(ear, minX, minY, size) {
 
     while (p && p.z <= maxZ) {
         if (p !== first && p !== last &&
+            (checkAspect ? Math.abs(aspect(p.prev, p, p.next) - 1) >= 0.2 : true) &&
             pointInTriangleLoop(ca, ab, bc, cax, cay, abx, aby, bcx, bcy, p.x, p.y) &&
             area(p.prev, p, p.next) >= 0) {
             return false;

--- a/src/earcut.js
+++ b/src/earcut.js
@@ -108,9 +108,7 @@ function earcutLinked(ear, triangles, dim, minX, minY, size, pass) {
             removeNode(ear);
 
             // skipping the next vertice leads to less sliver triangles
-            ear = next.next;
-            stop = next.next;
-
+            ear = stop = next.next;
             continue;
         }
 

--- a/src/earcut.js
+++ b/src/earcut.js
@@ -216,7 +216,7 @@ function isEarHashed(ear, minX, minY, size) {
     while (p && p.z <= maxZ) {
         if (p !== first && p !== last &&
             pointInTriangleLoop(ca, ab, bc, cax, cay, abx, aby, bcx, bcy, p.x, p.y) &&
-            area(p.prev, p, p.next) >= 0 ) {
+            area(p.prev, p, p.next) >= 0) {
             return false;
         }
 

--- a/src/earcut.js
+++ b/src/earcut.js
@@ -449,10 +449,29 @@ function getLeftmost(start) {
 }
 
 // check if a point lies within a convex triangle
-function pointInTriangle(ax, ay, bx, by, cx, cy, px, py) {
+/*function pointInTriangle(ax, ay, bx, by, cx, cy, px, py) {
     return (cx - px) * (ay - py) - (ax - px) * (cy - py) >= 0 &&
            (ax - px) * (by - py) - (bx - px) * (ay - py) >= 0 &&
            (bx - px) * (cy - py) - (cx - px) * (by - py) >= 0;
+}*/
+
+function pointInTriangle(ax, ay, bx, by, cx, cy, px, py) {
+    var axy = ax * py;
+    var ayx = ay * px;
+
+    var bxy = bx * py;
+    var byx = by * px;
+
+    var cxy = cx * py;
+    var cyx = cy * px;
+
+    var da = ayx - axy;
+    var dc = cyx - cxy;
+    var db = byx - bxy;
+
+    return cx * ay - ax * cy + dc - da >= 0 &&
+           ax * by - bx * ay + da - db >= 0 &&
+           bx * cy - cx * by + db - dc >= 0;
 }
 
 // check if a diagonal between two polygon nodes is valid (lies in polygon interior)

--- a/src/earcut.js
+++ b/src/earcut.js
@@ -151,23 +151,11 @@ function isEar(ear) {
     var ax = a.x, ay = a.y,
         bx = b.x, by = b.y,
         cx = c.x, cy = c.y,
-
-        ca = cx * ay - ax * cy,
-        ab = ax * by - bx * ay,
-        bc = bx * cy - cx * by,
-
-        cax = cx - ax,
-        cay = cy - ay,
-        abx = ax - bx,
-        aby = ay - by,
-        bcx = bx - cx,
-        bcy = by - cy,
-
         first = ear.prev;
 
     while (p !== first) {
         if (area(p.prev, p, p.next) >= 0 &&
-            pointInTriangleLoop(ca, ab, bc, cax, cay, abx, aby, bcx, bcy, p.x, p.y)) {
+            pointInTriangle(ax, ay, bx, by, cx, cy, p.x, p.y)) {
             return false;
         }
         p = p.next;
@@ -508,11 +496,11 @@ function getLeftmost(start) {
 }
 
 // check if a point lies within a convex triangle
-/*function pointInTriangle(ax, ay, bx, by, cx, cy, px, py) {
+function pointInTriangle(ax, ay, bx, by, cx, cy, px, py) {
     return (cx - px) * (ay - py) - (ax - px) * (cy - py) >= 0 &&
            (ax - px) * (by - py) - (bx - px) * (ay - py) >= 0 &&
            (bx - px) * (cy - py) - (cx - px) * (by - py) >= 0;
-}*/
+}
 
 // check if a point lies within a convex triangle
 function pointInTriangleLoop(ca, ab, bc, cax, cay, abx, aby, bcx, bcy, px, py) {

--- a/src/earcut.js
+++ b/src/earcut.js
@@ -211,20 +211,8 @@ function isEarHashed(ear, minX, minY, size) {
         first = ear.prev,
         last  = ear.next;
 
-    // first look for points inside the triangle in increasing z-order
-    var p = ear.nextZ;
-
-    while (p && p.z <= maxZ) {
-        if (p !== first && p !== last && area(p.prev, p, p.next) >= 0 &&
-            pointInTriangleLoop(ca, ab, bc, cax, cay, abx, aby, bcx, bcy, p.x, p.y)) {
-            return false;
-        }
-
-        p = p.nextZ;
-    }
-
-    // then look for points in decreasing z-order
-    p = ear.prevZ;
+    // first look for points inside the triangle in decreasing z-order
+    var p = ear.prevZ;
 
     while (p && p.z >= minZ) {
         if (p !== first && p !== last && area(p.prev, p, p.next) >= 0 &&
@@ -233,6 +221,18 @@ function isEarHashed(ear, minX, minY, size) {
         }
 
         p = p.prevZ;
+    }
+
+    // then increasing z-order
+    p = ear.nextZ;
+
+    while (p && p.z <= maxZ) {
+        if (p !== first && p !== last && area(p.prev, p, p.next) >= 0 &&
+            pointInTriangleLoop(ca, ab, bc, cax, cay, abx, aby, bcx, bcy, p.x, p.y)) {
+            return false;
+        }
+
+        p = p.nextZ;
     }
 
     return true;

--- a/src/earcut.js
+++ b/src/earcut.js
@@ -500,19 +500,25 @@ function pointInTriangleLoop(ca, ab, bc, ax, ay, bx, by, cx, cy, px, py) {
     var axy = ax * py;
     var ayx = ay * px;
 
-    var bxy = bx * py;
-    var byx = by * px;
-
     var cxy = cx * py;
     var cyx = cy * px;
 
     var da = ayx - axy;
     var dc = cyx - cxy;
+
+    if (ca + dc - da < 0)
+        return false;
+
+    var bxy = bx * py;
+    var byx = by * px;
+
     var db = byx - bxy;
 
-    return ca + dc - da >= 0 &&
-           ab + da - db >= 0 &&
-           bc + db - dc >= 0;
+    if (ab + da - db < 0 ||
+        bc + db - dc < 0)
+        return false;
+
+    return true;
 }
 
 // check if a diagonal between two polygon nodes is valid (lies in polygon interior)

--- a/src/earcut.js
+++ b/src/earcut.js
@@ -469,9 +469,8 @@ function equals(p1, p2) {
 function intersects(p1, q1, p2, q2) {
     if ((equals(p1, q1) && equals(p2, q2)) ||
         (equals(p1, q2) && equals(p2, q1))) return true;
-
-    return area(p1, q1, p2) * area(p1, q1, q2) <= 0 &&
-           area(p2, q2, p1) * area(p2, q2, q1) <= 0;
+    return area(p1, q1, p2) > 0 !== area(p1, q1, q2) > 0 &&
+           area(p2, q2, p1) > 0 !== area(p2, q2, q1) > 0;
 }
 
 // check if a polygon diagonal intersects any polygon segments

--- a/src/earcut.js
+++ b/src/earcut.js
@@ -469,8 +469,9 @@ function equals(p1, p2) {
 function intersects(p1, q1, p2, q2) {
     if ((equals(p1, q1) && equals(p2, q2)) ||
         (equals(p1, q2) && equals(p2, q1))) return true;
-    return area(p1, q1, p2) > 0 !== area(p1, q1, q2) > 0 &&
-           area(p2, q2, p1) > 0 !== area(p2, q2, q1) > 0;
+
+    return area(p1, q1, p2) * area(p1, q1, q2) < 0 &&
+           area(p2, q2, p1) * area(p2, q2, q1) < 0;
 }
 
 // check if a polygon diagonal intersects any polygon segments

--- a/src/earcut.js
+++ b/src/earcut.js
@@ -349,9 +349,18 @@ function findHoleBridge(hole, outerNode) {
 
     p = m.next;
 
+    var ax = hy < my ? hx : qx;
+    var cx = hy < my ? qx : hx;
+
+    var ay = hy, bx = mx,
+        by = my, cy = hy,
+        ca = cx * ay - ax * cy,
+        ab = ax * by - bx * ay,
+        bc = bx * cy - cx * by;
+
     while (p !== stop) {
         if (hx >= p.x && p.x >= mx && hx !== p.x &&
-                pointInTriangle(hy < my ? hx : qx, hy, mx, my, hy < my ? qx : hx, hy, p.x, p.y)) {
+            pointInTriangleLoop(ca, ab, bc, ax, ay, bx, by, cx, cy, p.x, p.y)) {
 
             tan = Math.abs(hy - p.y) / (hx - p.x); // tangential
 
@@ -468,34 +477,13 @@ function getLeftmost(start) {
 }
 
 // check if a point lies within a convex triangle
-// 6 mul 15 add = 21 total
 /*function pointInTriangle(ax, ay, bx, by, cx, cy, px, py) {
     return (cx - px) * (ay - py) - (ax - px) * (cy - py) >= 0 &&
            (ax - px) * (by - py) - (bx - px) * (ay - py) >= 0 &&
            (bx - px) * (cy - py) - (cx - px) * (by - py) >= 0;
 }*/
 
-// 12 mul 12 add = 24 total but now only 9 ops need for recalc in loops
-function pointInTriangle(ax, ay, bx, by, cx, cy, px, py) {
-    var axy = ax * py;
-    var ayx = ay * px;
-
-    var bxy = bx * py;
-    var byx = by * px;
-
-    var cxy = cx * py;
-    var cyx = cy * px;
-
-    var da = ayx - axy;
-    var dc = cyx - cxy;
-    var db = byx - bxy;
-
-    return cx * ay - ax * cy + dc - da >= 0 &&
-           ax * by - bx * ay + da - db >= 0 &&
-           bx * cy - cx * by + db - dc >= 0;
-}
-
-
+// check if a point lies within a convex triangle
 function pointInTriangleLoop(ca, ab, bc, ax, ay, bx, by, cx, cy, px, py) {
     var axy = ax * py;
     var ayx = ay * px;

--- a/src/earcut.js
+++ b/src/earcut.js
@@ -149,8 +149,8 @@ function isEar(ear) {
     var p = ear.next.next;
 
     while (p !== ear.prev) {
-        if (pointInTriangle(a.x, a.y, b.x, b.y, c.x, c.y, p.x, p.y) &&
-            area(p.prev, p, p.next) >= 0) return false;
+        if (area(p.prev, p, p.next) >= 0 &&
+            pointInTriangle(a.x, a.y, b.x, b.y, c.x, c.y, p.x, p.y)) return false;
         p = p.next;
     }
 

--- a/src/earcut.js
+++ b/src/earcut.js
@@ -241,15 +241,17 @@ function isEarHashed(ear, minX, minY, size) {
 // go through all polygon nodes and cure small local self-intersections
 function cureLocalIntersections(start, triangles, dim) {
     var p = start;
+    var invDim = 1 / dim;
+
     do {
         var a = p.prev,
             b = p.next.next;
 
         if (!equals(a, b) && intersects(a, p, p.next, b) && locallyInside(a, b) && locallyInside(b, a)) {
 
-            triangles.push(a.i / dim);
-            triangles.push(p.i / dim);
-            triangles.push(b.i / dim);
+            triangles.push(a.i * invDim);
+            triangles.push(p.i * invDim);
+            triangles.push(b.i * invDim);
 
             // remove two nodes involved
             removeNode(p);
@@ -475,8 +477,10 @@ function sortLinked(list) {
 // z-order of a point given coords and size of the data bounding box
 function zOrder(x, y, minX, minY, size) {
     // coords are transformed into non-negative 15-bit integer range
-    x = 32767 * (x - minX) / size;
-    y = 32767 * (y - minY) / size;
+    size = 32767 / size;
+
+    x = (x - minX) * size;
+    y = (y - minY) * size;
 
     x = (x | (x << 8)) & 0x00FF00FF;
     x = (x | (x << 4)) & 0x0F0F0F0F;

--- a/src/earcut.js
+++ b/src/earcut.js
@@ -485,25 +485,9 @@ function getLeftmost(start) {
 
 // check if a point lies within a convex triangle
 function pointInTriangleLoop(ca, ab, bc, ax, ay, bx, by, cx, cy, px, py) {
-    var axy = ax * py;
-    var ayx = ay * px;
-
-    var cxy = cx * py;
-    var cyx = cy * px;
-
-    var da = ayx - axy;
-    var dc = cyx - cxy;
-
-    if (ca + dc - da < 0)
-        return false;
-
-    var bxy = bx * py;
-    var byx = by * px;
-
-    var db = byx - bxy;
-
-    return ab + da - db >= 0 &&
-           bc + db - dc >= 0;
+    return ca + (cy - ay) * px - (cx - ax) * py >= 0 &&
+           ab + (ay - by) * px - (ax - bx) * py >= 0 &&
+           bc + (by - cy) * px - (bx - cx) * py >= 0;
 }
 
 // check if a diagonal between two polygon nodes is valid (lies in polygon interior)

--- a/src/earcut.js
+++ b/src/earcut.js
@@ -514,11 +514,8 @@ function pointInTriangleLoop(ca, ab, bc, ax, ay, bx, by, cx, cy, px, py) {
 
     var db = byx - bxy;
 
-    if (ab + da - db < 0 ||
-        bc + db - dc < 0)
-        return false;
-
-    return true;
+    return ab + da - db >= 0 &&
+           bc + db - dc >= 0;
 }
 
 // check if a diagonal between two polygon nodes is valid (lies in polygon interior)

--- a/src/earcut.js
+++ b/src/earcut.js
@@ -175,6 +175,10 @@ function isEarHashed(ear, minX, minY, size) {
         maxTX = a.x > b.x ? (a.x > c.x ? a.x : c.x) : (b.x > c.x ? b.x : c.x),
         maxTY = a.y > b.y ? (a.y > c.y ? a.y : c.y) : (b.y > c.y ? b.y : c.y);
 
+    size = 32767 / size;
+    minX *= size;
+    minY *= size;
+
     // z-order range for the current triangle bbox;
     var minZ = zOrder(minTX, minTY, minX, minY, size),
         maxZ = zOrder(maxTX, maxTY, minX, minY, size);
@@ -393,6 +397,11 @@ function findHoleBridge(hole, outerNode) {
 // interlink polygon nodes in z-order
 function indexCurve(start, minX, minY, size) {
     var p = start;
+
+    size = 32767 / size;
+    minX *= size;
+    minY *= size;
+
     do {
         if (p.z === null) p.z = zOrder(p.x, p.y, minX, minY, size);
         p.prevZ = p.prev;
@@ -461,12 +470,10 @@ function sortLinked(list) {
 
 
 // z-order of a point given coords and size of the data bounding box
-function zOrder(x, y, minX, minY, size) {
+function zOrder(x, y, minXs, minYs, size) {
     // coords are transformed into non-negative 15-bit integer range
-    size = 32767 / size;
-
-    x = (x - minX) * size;
-    y = (y - minY) * size;
+    x = x * size - minXs;
+    y = y * size - minYs;
 
     x = (x | (x << 8)) & 0x00FF00FF;
     x = (x | (x << 4)) & 0x0F0F0F0F;

--- a/src/earcut.js
+++ b/src/earcut.js
@@ -183,20 +183,16 @@ function isEarHashed(ear, minX, minY, size) {
     var minZ = zOrder(minTX, minTY, minX, minY, size),
         maxZ = zOrder(maxTX, maxTY, minX, minY, size);
 
-    var ax = a.x, ay = a.y,
-        bx = b.x, by = b.y,
-        cx = c.x, cy = c.y,
+    var ca = c.x * a.y - a.x * c.y,
+        ab = a.x * b.y - b.x * a.y,
+        bc = b.x * c.y - c.x * b.y,
 
-        ca = cx * ay - ax * cy,
-        ab = ax * by - bx * ay,
-        bc = bx * cy - cx * by,
-
-        cax = cx - ax,
-        cay = cy - ay,
-        abx = ax - bx,
-        aby = ay - by,
-        bcx = bx - cx,
-        bcy = by - cy,
+        cax = c.x - a.x,
+        cay = c.y - a.y,
+        abx = a.x - b.x,
+        aby = a.y - b.y,
+        bcx = b.x - c.x,
+        bcy = b.y - c.y,
 
         first = ear.prev,
         last  = ear.next;
@@ -205,8 +201,9 @@ function isEarHashed(ear, minX, minY, size) {
     var p = ear.prevZ;
 
     while (p && p.z >= minZ) {
-        if (p !== first && p !== last && area(p.prev, p, p.next) >= 0 &&
-            pointInTriangleLoop(ca, ab, bc, cax, cay, abx, aby, bcx, bcy, p.x, p.y)) {
+        if (p !== first && p !== last &&
+            pointInTriangleLoop(ca, ab, bc, cax, cay, abx, aby, bcx, bcy, p.x, p.y) &&
+            area(p.prev, p, p.next) >= 0) {
             return false;
         }
 
@@ -217,8 +214,9 @@ function isEarHashed(ear, minX, minY, size) {
     p = ear.nextZ;
 
     while (p && p.z <= maxZ) {
-        if (p !== first && p !== last && area(p.prev, p, p.next) >= 0 &&
-            pointInTriangleLoop(ca, ab, bc, cax, cay, abx, aby, bcx, bcy, p.x, p.y)) {
+        if (p !== first && p !== last &&
+            pointInTriangleLoop(ca, ab, bc, cax, cay, abx, aby, bcx, bcy, p.x, p.y) &&
+            area(p.prev, p, p.next) >= 0 ) {
             return false;
         }
 
@@ -325,20 +323,21 @@ function findHoleBridge(hole, outerNode) {
         hx = hole.x,
         hy = hole.y,
         qx = -Infinity,
-        m;
+        m, np;
 
     // find a segment intersected by a ray from the hole's leftmost point to the left;
     // segment's endpoint with lesser x will be potential connection point
     do {
-        if (hy <= p.y && hy >= p.next.y && p.next.y !== p.y) {
-            var x = p.x + (hy - p.y) * (p.next.x - p.x) / (p.next.y - p.y);
+        np = p.next;
+        if (hy <= p.y && hy >= np.y && np.y !== p.y) {
+            var x = p.x + (hy - p.y) * (np.x - p.x) / (np.y - p.y);
             if (x <= hx && x > qx) {
                 qx = x;
                 if (x === hx) {
                     if (hy === p.y) return p;
-                    if (hy === p.next.y) return p.next;
+                    if (hy === np.y) return np;
                 }
-                m = p.x < p.next.x ? p : p.next;
+                m = p.x < np.x ? p : np;
             }
         }
         p = p.next;
@@ -461,7 +460,7 @@ function sortLinked(list) {
         }
 
         tail.nextZ = null;
-        inSize *= 2;
+        inSize <<= 1;
 
     } while (numMerges > 1);
 

--- a/src/earcut.js
+++ b/src/earcut.js
@@ -178,9 +178,8 @@ function isEarHashed(ear, minX, minY, size) {
     var p = ear.nextZ;
 
     while (p && p.z <= maxZ) {
-        if (p !== ear.prev && p !== ear.next &&
-            pointInTriangle(a.x, a.y, b.x, b.y, c.x, c.y, p.x, p.y) &&
-            area(p.prev, p, p.next) >= 0) return false;
+        if (p !== ear.prev && p !== ear.next && area(p.prev, p, p.next) >= 0 &&
+            pointInTriangle(a.x, a.y, b.x, b.y, c.x, c.y, p.x, p.y)) return false;
         p = p.nextZ;
     }
 
@@ -188,9 +187,8 @@ function isEarHashed(ear, minX, minY, size) {
     p = ear.prevZ;
 
     while (p && p.z >= minZ) {
-        if (p !== ear.prev && p !== ear.next &&
-            pointInTriangle(a.x, a.y, b.x, b.y, c.x, c.y, p.x, p.y) &&
-            area(p.prev, p, p.next) >= 0) return false;
+        if (p !== ear.prev && p !== ear.next && area(p.prev, p, p.next) >= 0 &&
+            pointInTriangle(a.x, a.y, b.x, b.y, c.x, c.y, p.x, p.y)) return false;
         p = p.prevZ;
     }
 

--- a/src/earcut.js
+++ b/src/earcut.js
@@ -174,12 +174,18 @@ function isEarHashed(ear, minX, minY, size) {
     var minZ = zOrder(minTX, minTY, minX, minY, size),
         maxZ = zOrder(maxTX, maxTY, minX, minY, size);
 
+    var ax = a.x, ay = a.y,
+        bx = b.x, by = b.y,
+        cx = c.x, cy = c.y,
+        first = ear.prev,
+        last  = ear.next;
+
     // first look for points inside the triangle in increasing z-order
     var p = ear.nextZ;
 
     while (p && p.z <= maxZ) {
-        if (p !== ear.prev && p !== ear.next && area(p.prev, p, p.next) >= 0 &&
-            pointInTriangle(a.x, a.y, b.x, b.y, c.x, c.y, p.x, p.y)) return false;
+        if (p !== first && p !== last && area(p.prev, p, p.next) >= 0 &&
+            pointInTriangle(ax, ay, bx, by, cx, cy, p.x, p.y)) return false;
         p = p.nextZ;
     }
 
@@ -187,8 +193,8 @@ function isEarHashed(ear, minX, minY, size) {
     p = ear.prevZ;
 
     while (p && p.z >= minZ) {
-        if (p !== ear.prev && p !== ear.next && area(p.prev, p, p.next) >= 0 &&
-            pointInTriangle(a.x, a.y, b.x, b.y, c.x, c.y, p.x, p.y)) return false;
+        if (p !== first && p !== last && area(p.prev, p, p.next) >= 0 &&
+            pointInTriangle(ax, ay, bx, by, cx, cy, p.x, p.y)) return false;
         p = p.prevZ;
     }
 
@@ -478,7 +484,7 @@ function intersectsPolygon(a, b) {
     var p = a;
     do {
         if (p.i !== a.i && p.next.i !== a.i && p.i !== b.i && p.next.i !== b.i &&
-                intersects(p, p.next, a, b)) return true;
+            intersects(p, p.next, a, b)) return true;
         p = p.next;
     } while (p !== a);
 


### PR DESCRIPTION
Ear clipping algorithm produce very often sleazy triangles that has a performance issue for gpu's rasterizer. So to avoid this I try to introduce some additional quality condition. Now is very unstable prototype which needs further improvements. The basic idea is checking aspect ratio of next ear. And if aspect close to one with some threshold range we have great candidate, in another case we fallback to old approach.

But, I have several side effects. Maybe you help figure out problems?

### Examples of old and new topology:

**Before**
![Before](https://www.dropbox.com/s/o7uz9d973dcug63/Before-imp-topo.jpg?raw=1)

**After**
![After](https://www.dropbox.com/s/sel5kqqcdeozuhi/After-imp-topo.jpg?raw=1)