### PR TITLE
Search with equal priority in both z-order directions

### DIFF
--- a/src/earcut.js
+++ b/src/earcut.js
@@ -174,24 +174,36 @@ function isEarHashed(ear, minX, minY, invSize) {
     var minZ = zOrder(minTX, minTY, minX, minY, invSize),
         maxZ = zOrder(maxTX, maxTY, minX, minY, invSize);
 
-    // first look for points inside the triangle in increasing z-order
-    var p = ear.nextZ;
+    var p = ear.prevZ,
+        n = ear.nextZ;
 
-    while (p && p.z <= maxZ) {
+    // look for points inside the triangle in both directions
+    while (p && p.z >= minZ && n && n.z <= maxZ) {
         if (p !== ear.prev && p !== ear.next &&
             pointInTriangle(a.x, a.y, b.x, b.y, c.x, c.y, p.x, p.y) &&
             area(p.prev, p, p.next) >= 0) return false;
-        p = p.nextZ;
+        p = p.prevZ;
+
+        if (n !== ear.prev && n !== ear.next &&
+            pointInTriangle(a.x, a.y, b.x, b.y, c.x, c.y, n.x, n.y) &&
+            area(n.prev, n, n.next) >= 0) return false;
+        n = n.nextZ;
     }
 
-    // then look for points in decreasing z-order
-    p = ear.prevZ;
-
+    // look for remaining points in decreasing z-order
     while (p && p.z >= minZ) {
         if (p !== ear.prev && p !== ear.next &&
             pointInTriangle(a.x, a.y, b.x, b.y, c.x, c.y, p.x, p.y) &&
             area(p.prev, p, p.next) >= 0) return false;
         p = p.prevZ;
+    }
+
+    // look for remaining points in increasing z-order
+    while (n && n.z <= maxZ) {
+        if (n !== ear.prev && n !== ear.next &&
+            pointInTriangle(a.x, a.y, b.x, b.y, c.x, c.y, n.x, n.y) &&
+            area(n.prev, n, n.next) >= 0) return false;
+        n = n.nextZ;
     }
 
     return true;


### PR DESCRIPTION
This gives a slight speedup for more complex polygons.

Before:
```
typical OSM building (15 vertices): x 644,598 ops/sec ±0.96% (89 runs sampled)
dude shape (94 vertices): x 46,829 ops/sec ±1.39% (96 runs sampled)
dude shape with holes (104 vertices): x 37,816 ops/sec ±1.20% (91 runs sampled)
complex OSM water (2523 vertices): x 588 ops/sec ±0.75% (91 runs sampled)
```

After:
```
typical OSM building (15 vertices): x 632,252 ops/sec ±1.60% (89 runs sampled)
dude shape (94 vertices): x 48,956 ops/sec ±1.45% (94 runs sampled)
dude shape with holes (104 vertices): x 39,665 ops/sec ±1.51% (95 runs sampled)
complex OSM water (2523 vertices): x 659 ops/sec ±0.75% (91 runs sampled)
```

Results in gl-js:

https://bl.ocks.org/anonymous/raw/c415471d58758dd81650dec97d35b2f8/