### PR TITLE
Migrate to rollup, use proper ESM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-  - "4"
+  - "6"
   - "node"
 script:
   - npm test

--- a/package.json
+++ b/package.json
@@ -2,19 +2,19 @@
   "name": "earcut",
   "version": "2.1.3",
   "description": "The fastest and smallest JavaScript polygon triangulation library for your WebGL apps",
-  "main": "src/earcut.js",
+  "main": "dist/earcut.cjs.js",
+  "module": "src/earcut.js",
   "unpkg": "dist/earcut.dev.js",
   "jsdelivr": "dist/earcut.dev.js",
   "files": [
-    "dist/earcut.min.js",
-    "dist/earcut.dev.js"
+    "dist"
   ],
   "scripts": {
     "test": "eslint src test/test.js && tape test/test.js",
-    "watch": "mkdirp dist && watchify -v -d src/earcut.js -s earcut -o dist/earcut.dev.js",
-    "build-dev": "mkdirp dist && browserify -d src/earcut.js -s earcut > dist/earcut.dev.js",
-    "build-min": "mkdirp dist && browserify src/earcut.js -s earcut | uglifyjs -c warnings=false -m > dist/earcut.min.js",
-    "prepare": "npm run build-dev && npm run build-min",
+    "watch": "npm run build -- --watch",
+    "prebuild": "mkdirp dist",
+    "build": "rollup -c",
+    "prepare": "npm run build",
     "cov": "istanbul cover test/*.js",
     "coveralls": "istanbul cover test/*.js && coveralls < ./coverage/lcov.info"
   },
@@ -22,18 +22,18 @@
   "license": "ISC",
   "devDependencies": {
     "benchmark": "^2.1.4",
-    "browserify": "^14.5.0",
     "coveralls": "^3.0.0",
     "eslint": "^4.14.0",
     "eslint-config-mourner": "^2.0.3",
     "istanbul": "^0.4.5",
     "mkdirp": "^0.5.1",
-    "tape": "^4.8.0",
-    "uglify-js": "^3.3.4",
-    "watchify": "^3.9.0"
+    "rollup": "^0.64.1",
+    "rollup-plugin-uglify": "^4.0.0",
+    "tape": "^4.8.0"
   },
   "eslintConfig": {
     "extends": "mourner",
+    "sourceType": "module",
     "rules": {
       "no-unmodified-loop-condition": 0
     }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,40 @@
+import { uglify } from 'rollup-plugin-uglify'
+import pkg from './package.json'
+
+const createConfig = ({
+    input = pkg.module,
+    output,
+    min = false,
+} = {}) => ({
+    input,
+    output: Object.assign({ name: pkg.name, exports: 'named' }, output),
+    plugins: [
+        min && uglify({
+            compress: {
+                warnings: false
+            },
+        }),
+    ].filter(Boolean)
+})
+
+export default [
+    createConfig({
+        output: {
+            file: pkg.main,
+            format: 'cjs',
+        },
+    }),
+    createConfig({
+        output: {
+            file: pkg.unpkg,
+            format: 'umd',
+        },
+    }),
+    createConfig({
+        output: {
+            file: pkg.unpkg.replace('dev', 'min'),
+            format: 'umd',
+        },
+        min: true,
+    }),
+]

--- a/src/earcut.js
+++ b/src/earcut.js
@@ -1,9 +1,4 @@
-'use strict';
-
-module.exports = earcut;
-module.exports.default = earcut;
-
-function earcut(data, holeIndices, dim) {
+export default function earcut(data, holeIndices, dim) {
 
     dim = dim || 2;
 
@@ -595,7 +590,7 @@ function Node(i, x, y) {
 
 // return a percentage difference between the polygon area and its triangulation area;
 // used to verify correctness of triangulation
-earcut.deviation = function (data, holeIndices, dim, triangles) {
+export function deviation(data, holeIndices, dim, triangles) {
     var hasHoles = holeIndices && holeIndices.length;
     var outerLen = hasHoles ? holeIndices[0] * dim : data.length;
 
@@ -632,7 +627,7 @@ function signedArea(data, start, end, dim) {
 }
 
 // turn a polygon in a multi-dimensional array form (e.g. as in GeoJSON) into a form Earcut accepts
-earcut.flatten = function (data) {
+export function flatten(data) {
     var dim = data[0][0].length,
         result = {vertices: [], holes: [], dimensions: dim},
         holeIndex = 0;


### PR DESCRIPTION
⚠️ this is a breaking change because of exported shape change

Benefits:
- earcut.min.js script from 2777 to 2555 bytes (gzipped)
- supports tree-shaking