### PR TITLE
fix description of area()

### DIFF
--- a/src/earcut.js
+++ b/src/earcut.js
@@ -469,7 +469,7 @@ function isValidDiagonal(a, b) {
            locallyInside(a, b) && locallyInside(b, a) && middleInside(a, b);
 }
 
-// signed area of a triangle
+// signed area of a parallelogram
 function area(p, q, r) {
     return (q.y - p.y) * (r.x - q.x) - (q.x - p.x) * (r.y - q.y);
 }

--- a/src/earcut.js
+++ b/src/earcut.js
@@ -469,7 +469,7 @@ function isValidDiagonal(a, b) {
            locallyInside(a, b) && locallyInside(b, a) && middleInside(a, b);
 }
 
-// signed area of a parallelogram
+// signed area of a triangle, times two
 function area(p, q, r) {
     return (q.y - p.y) * (r.x - q.x) - (q.x - p.x) * (r.y - q.y);
 }


### PR DESCRIPTION
that appears to be the wedge product, aka area of parallelogram, not triangle. it is twice the area of the triangle. example  with points 0,0. 4,0.  4,3.   area() = 12, triangle area = 6. thx