### PR TITLE
Fix incorrect equality case in intersection test

### DIFF
--- a/src/earcut.js
+++ b/src/earcut.js
@@ -481,7 +481,7 @@ function equals(p1, p2) {
 
 // check if two segments intersect
 function intersects(p1, q1, p2, q2) {
-    if ((equals(p1, q1) && equals(p2, q2)) ||
+    if ((equals(p1, p2) && equals(q1, q2)) ||
         (equals(p1, q2) && equals(p2, q1))) return true;
     return area(p1, q1, p2) > 0 !== area(p1, q1, q2) > 0 &&
            area(p2, q2, p1) > 0 !== area(p2, q2, q1) > 0;


### PR DESCRIPTION
@mrgreywater this was indeed a bug, although I don't see any difference for the test deviations. Ref #110 