### PR TITLE
Fix typo regarding holes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Signature: `earcut(vertices[, holes, dimensions = 2])`.
 
 * `vertices` is a flat array of vertex coordinates like `[x0,y0, x1,y1, x2,y2, ...]`.
 * `holes` is an array of hole _indices_ if any
-  (e.g. `[5, 8]` for a 12-vertex input would mean one hole with vertices 5&ndash;7 and another with 8&ndash;11).
+  (e.g. `[5, 8]` for a 12-vertex input would mean one hole with vertices 5&ndash;7 and another with 8&ndash;10).
 * `dimensions` is the number of coordinates per vertex in the input array (`2` by default). Only two are used for triangulation (`x` and `y`), and the rest are ignored.
 
 Each group of three vertex indices in the resulting array forms a triangle.


### PR DESCRIPTION
This wasn't making sense. How does providing two indices indicate that one hole would be 3 vertices and one would be 4?