### PR TITLE
Perf improvements (radis sort, better pathological cases handling)

### DIFF
--- a/src/earcut.js
+++ b/src/earcut.js
@@ -658,10 +658,10 @@ function pointInTriangle(ax, ay, bx, by, cx, cy, px, py) {
 // check if a diagonal between two polygon nodes is valid (lies in polygon interior)
 /** @param {Node} a @param {Node} b @returns {boolean} true when the diagonal is valid */
 function isValidDiagonal(a, b) {
-    return a.next.i !== b.i && !intersectsPolygon(a, b) && // doesn't intersect other edges
-           (locallyInside(a, b) && locallyInside(b, a) && middleInside(a, b) && // locally visible
-            (area(a.prev, a, b.prev) !== 0 || area(a, b.prev, b) !== 0) || // does not create opposite-facing sectors
-            equals(a, b) && area(a.prev, a, a.next) > 0 && area(b.prev, b, b.next) > 0); // special zero-length case
+    const zeroLength = equals(a, b) && area(a.prev, a, a.next) > 0 && area(b.prev, b, b.next) > 0; // degenerate case
+    return a.next.i !== b.i && (zeroLength || locallyInside(a, b) && locallyInside(b, a) && // // locally visible
+        (area(a.prev, a, b.prev) !== 0 || area(a, b.prev, b) !== 0)) && // no opposite-facing sectors
+        !intersectsPolygon(a, b) && (zeroLength || middleInside(a, b)); // doesn't intersect other edges, diagonal inside polygon
 }
 
 // signed area of a triangle

--- a/src/earcut.js
+++ b/src/earcut.js
@@ -183,82 +183,50 @@ function earcutLinked(ear, triangles, dim, minX, minY, invSize, pass) {
 // check whether a polygon node forms a valid ear with adjacent nodes
 /** @param {Node} ear @returns {boolean} */
 function isEar(ear) {
-    const a = ear.prev,
-        b = ear,
-        c = ear.next;
-
     // reflex check (area(a, b, c) >= 0) is hoisted into the earcutLinked caller to avoid non-inlined call here
-
-    // make sure we don't have other points inside the potential ear; the point-in-triangle
-    // test (false when the point coincides with the first vertex a) is inlined here and in
-    // isEarHashed rather than called — V8 doesn't inline it and the call sits in the hot loop
-    const ax = a.x, bx = b.x, cx = c.x, ay = a.y, by = b.y, cy = c.y;
-
-    // triangle bbox
-    const x0 = Math.min(ax, bx, cx),
+    const a = ear.prev, b = ear, c = ear.next,
+        ax = a.x, bx = b.x, cx = c.x, ay = a.y, by = b.y, cy = c.y,
+        x0 = Math.min(ax, bx, cx), // triangle bbox
         y0 = Math.min(ay, by, cy),
         x1 = Math.max(ax, bx, cx),
         y1 = Math.max(ay, by, cy);
 
+    // make sure we don't have other points inside the potential ear
     let p = c.next;
     while (p !== a) {
         if (p.x >= x0 && p.x <= x1 && p.y >= y0 && p.y <= y1 &&
-            !(ax === p.x && ay === p.y) && (cx - p.x) * (ay - p.y) >= (ax - p.x) * (cy - p.y) && (ax - p.x) * (by - p.y) >= (bx - p.x) * (ay - p.y) && (bx - p.x) * (cy - p.y) >= (cx - p.x) * (by - p.y) &&
+            !(ax === p.x && ay === p.y) && pointInTriangle(ax, ay, bx, by, cx, cy, p.x, p.y) &&
             area(p.prev, p, p.next) >= 0) return false;
         p = p.next;
     }
-
     return true;
 }
 
 /** @param {Node} ear @param {number} minX @param {number} minY @param {number} invSize @returns {boolean} */
 function isEarHashed(ear, minX, minY, invSize) {
-    const a = ear.prev,
-        b = ear,
-        c = ear.next;
-
     // reflex check is hoisted into the earcutLinked caller (see isEar)
-
-    const ax = a.x, bx = b.x, cx = c.x, ay = a.y, by = b.y, cy = c.y;
-
-    // triangle bbox
-    const x0 = Math.min(ax, bx, cx),
+    const a = ear.prev, b = ear, c = ear.next,
+        ax = a.x, bx = b.x, cx = c.x, ay = a.y, by = b.y, cy = c.y,
+        x0 = Math.min(ax, bx, cx), // triangle bbox
         y0 = Math.min(ay, by, cy),
         x1 = Math.max(ax, bx, cx),
-        y1 = Math.max(ay, by, cy);
-
-    // z-order range for the current triangle bbox;
-    const minZ = zOrder(x0, y0, minX, minY, invSize),
+        y1 = Math.max(ay, by, cy),
+        minZ = zOrder(x0, y0, minX, minY, invSize), // z-order range for the current triangle bbox;
         maxZ = zOrder(x1, y1, minX, minY, invSize);
 
     let p = ear.prevZ,
         n = ear.nextZ;
 
-    // look for points inside the triangle in both directions
-    while (p && p.z >= minZ && n && n.z <= maxZ) {
+    while (p && p.z >= minZ) { // look for points inside the triangle in decreasing z-order
         if (p.x >= x0 && p.x <= x1 && p.y >= y0 && p.y <= y1 && p !== c &&
-            !(ax === p.x && ay === p.y) && (cx - p.x) * (ay - p.y) >= (ax - p.x) * (cy - p.y) && (ax - p.x) * (by - p.y) >= (bx - p.x) * (ay - p.y) && (bx - p.x) * (cy - p.y) >= (cx - p.x) * (by - p.y) && area(p.prev, p, p.next) >= 0) return false;
-        p = p.prevZ;
-
-        if (n.x >= x0 && n.x <= x1 && n.y >= y0 && n.y <= y1 && n !== c &&
-            !(ax === n.x && ay === n.y) && (cx - n.x) * (ay - n.y) >= (ax - n.x) * (cy - n.y) && (ax - n.x) * (by - n.y) >= (bx - n.x) * (ay - n.y) && (bx - n.x) * (cy - n.y) >= (cx - n.x) * (by - n.y) && area(n.prev, n, n.next) >= 0) return false;
-        n = n.nextZ;
-    }
-
-    // look for remaining points in decreasing z-order
-    while (p && p.z >= minZ) {
-        if (p.x >= x0 && p.x <= x1 && p.y >= y0 && p.y <= y1 && p !== c &&
-            !(ax === p.x && ay === p.y) && (cx - p.x) * (ay - p.y) >= (ax - p.x) * (cy - p.y) && (ax - p.x) * (by - p.y) >= (bx - p.x) * (ay - p.y) && (bx - p.x) * (cy - p.y) >= (cx - p.x) * (by - p.y) && area(p.prev, p, p.next) >= 0) return false;
+            !(ax === p.x && ay === p.y) && pointInTriangle(ax, ay, bx, by, cx, cy, p.x, p.y) && area(p.prev, p, p.next) >= 0) return false;
         p = p.prevZ;
     }
-
-    // look for remaining points in increasing z-order
-    while (n && n.z <= maxZ) {
+    while (n && n.z <= maxZ) { // look for points in increasing z-order
         if (n.x >= x0 && n.x <= x1 && n.y >= y0 && n.y <= y1 && n !== c &&
-            !(ax === n.x && ay === n.y) && (cx - n.x) * (ay - n.y) >= (ax - n.x) * (cy - n.y) && (ax - n.x) * (by - n.y) >= (bx - n.x) * (ay - n.y) && (bx - n.x) * (cy - n.y) >= (cx - n.x) * (by - n.y) && area(n.prev, n, n.next) >= 0) return false;
+            !(ax === n.x && ay === n.y) && pointInTriangle(ax, ay, bx, by, cx, cy, n.x, n.y) && area(n.prev, n, n.next) >= 0) return false;
         n = n.nextZ;
     }
-
     return true;
 }
 

--- a/src/earcut.js
+++ b/src/earcut.js
@@ -1,4 +1,3 @@
-
 /**
  * A vertex in a circular doubly linked list representing a polygon ring.
  * `prev`/`next` are always linked (set immediately after {@link createNode}), so they're typed
@@ -47,11 +46,7 @@ export default function earcut(data, holeIndices, dim = 2) {
 
     let minX = 0, minY = 0, invSize = 0;
 
-    if (hasHoles) {
-        outerNode = eliminateHoles(data, holeIndices, outerNode, dim);
-        // collapse collinear/coincident points across the whole merged ring once before clipping
-        outerNode = filterPoints(outerNode);
-    }
+    if (hasHoles) outerNode = eliminateHoles(data, holeIndices, outerNode, dim);
 
     // if the shape is not too simple, we'll use z-order curve hash later; calculate polygon bbox
     if (data.length > 80 * dim) {
@@ -74,7 +69,7 @@ export default function earcut(data, holeIndices, dim = 2) {
         invSize = invSize !== 0 ? 32767 / invSize : 0;
     }
 
-    earcutLinked(outerNode, triangles, dim, minX, minY, invSize, 0);
+    earcutLinked(outerNode, triangles, minX, minY, invSize);
 
     return triangles;
 }
@@ -128,14 +123,12 @@ function filterPoints(start, end = start) {
 }
 
 // main ear slicing loop which triangulates a polygon (given as a linked list)
-/** @param {Node | null} ear @param {number[]} triangles @param {number} dim @param {number} minX @param {number} minY @param {number} invSize @param {number} pass */
-function earcutLinked(ear, triangles, dim, minX, minY, invSize, pass) {
-    if (!ear) return;
-
+/** @param {Node} ear @param {number[]} triangles @param {number} minX @param {number} minY @param {number} invSize */
+function earcutLinked(ear, triangles, minX, minY, invSize) {
     // interlink polygon nodes in z-order
-    if (!pass && invSize) indexCurve(ear, minX, minY, invSize);
+    if (invSize) indexCurve(ear, minX, minY, invSize);
 
-    let stop = ear;
+    let stop = ear, cured = false;
 
     // iterate through ears, slicing them one by one
     while (ear.prev !== ear.next) {
@@ -159,22 +152,21 @@ function earcutLinked(ear, triangles, dim, minX, minY, invSize, pass) {
         // if we looped through the whole remaining polygon and can't find any more ears
         if (ear === stop) {
             // try filtering collinear/coincident points and slicing again — repeat as long as
-            // filtering actually removes nodes, since each removal can expose new ears. only once
-            // filtering can make no further progress do we fall through to the costlier stages.
+            // filtering actually removes nodes, since each removal can expose new ears
             filteredOut = false;
             ear = filterPoints(ear);
             if (filteredOut) { stop = ear; continue; }
 
-            // filtering is exhausted: cure small local self-intersections, then retry
-            if (!pass) {
+            // filtering is exhausted: cure small local self-intersections once, then retry
+            if (!cured) {
                 ear = cureLocalIntersections(ear, triangles);
-                earcutLinked(ear, triangles, dim, minX, minY, invSize, 1);
-
-            // as a last resort, try splitting the remaining polygon into two
-            } else {
-                splitEarcut(ear, triangles, dim, minX, minY, invSize);
+                stop = ear;
+                cured = true;
+                continue;
             }
 
+            // as a last resort, try splitting the remaining polygon into two
+            splitEarcut(ear, triangles, minX, minY, invSize);
             break;
         }
     }
@@ -257,8 +249,8 @@ function cureLocalIntersections(start, triangles) {
 }
 
 // try splitting polygon into two and triangulate them independently
-/** @param {Node} start @param {number[]} triangles @param {number} dim @param {number} minX @param {number} minY @param {number} invSize */
-function splitEarcut(start, triangles, dim, minX, minY, invSize) {
+/** @param {Node} start @param {number[]} triangles @param {number} minX @param {number} minY @param {number} invSize */
+function splitEarcut(start, triangles, minX, minY, invSize) {
     // look for a valid diagonal that divides the polygon into two
     let a = start;
     do {
@@ -273,8 +265,8 @@ function splitEarcut(start, triangles, dim, minX, minY, invSize) {
                 c = filterPoints(c, c.next);
 
                 // run earcut on each half
-                earcutLinked(a, triangles, dim, minX, minY, invSize, 0);
-                earcutLinked(c, triangles, dim, minX, minY, invSize, 0);
+                earcutLinked(a, triangles, minX, minY, invSize);
+                earcutLinked(c, triangles, minX, minY, invSize);
                 return;
             }
             b = b.next;
@@ -314,7 +306,8 @@ function eliminateHoles(data, holeIndices, outerNode, dim) {
     }
     indexActive = false;
 
-    return outerNode;
+    // collapse collinear/coincident points across the whole merged ring once before clipping
+    return filterPoints(outerNode);
 }
 
 /** @param {Node} a @param {Node} b @returns {number} */

--- a/src/earcut.js
+++ b/src/earcut.js
@@ -20,6 +20,10 @@
 /** @type {Set<Node>} */
 const steiners = new Set();
 
+// set by filterPoints whenever it removes at least one node; read by earcutLinked's stall
+// handler to decide whether another clip pass is worth attempting before the costlier stages
+let filteredOut = false;
+
 /**
  * Triangulate a polygon given as a flat array of vertex coordinates.
  *
@@ -110,6 +114,7 @@ function filterPoints(start, end = start) {
         if (p !== p.next && (steiners.size === 0 || !steiners.has(p)) &&
             (equals(p, p.next) || area(p.prev, p, p.next) === 0)) {
             if (full || p === end) end = p.prev; // pull the stop bound back past the removal
+            filteredOut = true;
             removeNode(p);
             p = p.prev;         // re-check the predecessor
             again = true;
@@ -153,17 +158,20 @@ function earcutLinked(ear, triangles, dim, minX, minY, invSize, pass) {
 
         // if we looped through the whole remaining polygon and can't find any more ears
         if (ear === stop) {
-            // try filtering points and slicing again
-            if (!pass) {
-                earcutLinked(filterPoints(ear), triangles, dim, minX, minY, invSize, 1);
+            // try filtering collinear/coincident points and slicing again — repeat as long as
+            // filtering actually removes nodes, since each removal can expose new ears. only once
+            // filtering can make no further progress do we fall through to the costlier stages.
+            filteredOut = false;
+            ear = filterPoints(ear);
+            if (filteredOut) { stop = ear; continue; }
 
-            // if this didn't work, try curing all small self-intersections locally
-            } else if (pass === 1) {
-                ear = cureLocalIntersections(filterPoints(ear), triangles);
-                earcutLinked(ear, triangles, dim, minX, minY, invSize, 2);
+            // filtering is exhausted: cure small local self-intersections, then retry
+            if (!pass) {
+                ear = cureLocalIntersections(ear, triangles);
+                earcutLinked(ear, triangles, dim, minX, minY, invSize, 1);
 
             // as a last resort, try splitting the remaining polygon into two
-            } else if (pass === 2) {
+            } else {
                 splitEarcut(ear, triangles, dim, minX, minY, invSize);
             }
 

--- a/src/earcut.js
+++ b/src/earcut.js
@@ -140,10 +140,8 @@ function earcutLinked(ear, triangles, minX, minY, invSize) {
             triangles.push(prev.i, ear.i, next.i); // cut off the triangle
 
             removeNode(ear);
-
             ear = next;
             stop = next;
-
             continue;
         }
 
@@ -186,9 +184,8 @@ function isEar(ear) {
     // make sure we don't have other points inside the potential ear
     let p = c.next;
     while (p !== a) {
-        if (p.x >= x0 && p.x <= x1 && p.y >= y0 && p.y <= y1 &&
-            !(ax === p.x && ay === p.y) && pointInTriangle(ax, ay, bx, by, cx, cy, p.x, p.y) &&
-            area(p.prev, p, p.next) >= 0) return false;
+        if (p.x >= x0 && p.x <= x1 && p.y >= y0 && p.y <= y1 && !(ax === p.x && ay === p.y) &&
+            pointInTriangle(ax, ay, bx, by, cx, cy, p.x, p.y) && area(p.prev, p, p.next) >= 0) return false;
         p = p.next;
     }
     return true;
@@ -206,17 +203,16 @@ function isEarHashed(ear, minX, minY, invSize) {
         minZ = zOrder(x0, y0, minX, minY, invSize), // z-order range for the current triangle bbox;
         maxZ = zOrder(x1, y1, minX, minY, invSize);
 
-    let p = ear.prevZ,
-        n = ear.nextZ;
-
+    let p = ear.prevZ;
     while (p && p.z >= minZ) { // look for points inside the triangle in decreasing z-order
-        if (p.x >= x0 && p.x <= x1 && p.y >= y0 && p.y <= y1 && p !== c &&
-            !(ax === p.x && ay === p.y) && pointInTriangle(ax, ay, bx, by, cx, cy, p.x, p.y) && area(p.prev, p, p.next) >= 0) return false;
+        if (p.x >= x0 && p.x <= x1 && p.y >= y0 && p.y <= y1 && p !== c && !(ax === p.x && ay === p.y) &&
+            pointInTriangle(ax, ay, bx, by, cx, cy, p.x, p.y) && area(p.prev, p, p.next) >= 0) return false;
         p = p.prevZ;
     }
+    let n = ear.nextZ;
     while (n && n.z <= maxZ) { // look for points in increasing z-order
-        if (n.x >= x0 && n.x <= x1 && n.y >= y0 && n.y <= y1 && n !== c &&
-            !(ax === n.x && ay === n.y) && pointInTriangle(ax, ay, bx, by, cx, cy, n.x, n.y) && area(n.prev, n, n.next) >= 0) return false;
+        if (n.x >= x0 && n.x <= x1 && n.y >= y0 && n.y <= y1 && n !== c && !(ax === n.x && ay === n.y) &&
+            pointInTriangle(ax, ay, bx, by, cx, cy, n.x, n.y) && area(n.prev, n, n.next) >= 0) return false;
         n = n.nextZ;
     }
     return true;
@@ -514,11 +510,19 @@ function sectorContainsSector(m, p) {
     return area(m.prev, m, p.prev) < 0 && area(p.next, m, m.next) < 0;
 }
 
-// scratch array of node refs, reused across calls and grown on demand
+// scratch buffers reused across calls and grown on demand: two node-ref arrays that
+// ping-pong during the radix passes, plus parallel z-value arrays so the passes read
+// z from contiguous memory instead of dereferencing each node. 256-entry histogram for
+// 8-bit digits; the small histogram keeps per-call setup cheap (most rings are short)
 /** @type {Node[]} */
 const sortArr = [];
+/** @type {Node[]} */
+let sortBuf = [];
+let zArr = new Uint32Array(0);
+let zBuf = new Uint32Array(0);
+const counts = new Uint32Array(256);
 
-// interlink polygon nodes in z-order: collect into an array, quicksort by z, relink
+// interlink polygon nodes in z-order: collect into an array, sort by z, relink
 /** @param {Node} start @param {number} minX @param {number} minY @param {number} invSize */
 function indexCurve(start, minX, minY, invSize) {
     let p = start;
@@ -530,7 +534,7 @@ function indexCurve(start, minX, minY, invSize) {
         p = p.next;
     } while (p !== start);
 
-    quicksortNodes(sortArr, 0, n - 1);
+    sortNodes(n);
 
     /** @type {Node | null} */
     let prev = null;
@@ -543,35 +547,48 @@ function indexCurve(start, minX, minY, invSize) {
     /** @type {Node} */ (prev).nextZ = null;
 }
 
-// quicksort an array of nodes by z; middle-element pivot + insertion sort for small ranges
-/** @param {Node[]} arr @param {number} left @param {number} right */
-function quicksortNodes(arr, left, right) {
-    while (right - left > 20) {
-        // middle pivot splits already-sorted/reversed runs evenly; real ring-order-by-z data
-        // is non-adversarial, so the median-of-three guard isn't needed
-        const pivot = arr[(left + right) >> 1].z;
-
-        let i = left, j = right, t;
-        while (i <= j) {
-            while (arr[i].z < pivot) i++;
-            while (arr[j].z > pivot) j--;
-            if (i <= j) { t = arr[i]; arr[i] = arr[j]; arr[j] = t; i++; j--; }
+// sort the first n nodes of sortArr by z, in place: insertion sort for small n (cheaper
+// than histogram setup), else LSD radix in four 8-bit passes (covering z's 30 bits)
+/** @param {number} n */
+function sortNodes(n) {
+    if (n <= 32) {
+        for (let i = 1; i < n; i++) {
+            const node = sortArr[i], z = node.z;
+            let j = i - 1;
+            while (j >= 0 && sortArr[j].z > z) { sortArr[j + 1] = sortArr[j]; j--; }
+            sortArr[j + 1] = node;
         }
-        // recurse into the smaller half, loop on the larger to bound stack depth
-        if (j - left < right - i) {
-            quicksortNodes(arr, left, j);
-            left = i;
-        } else {
-            quicksortNodes(arr, i, right);
-            right = j;
-        }
+        return;
     }
-    // insertion sort the small remaining range
-    for (let i = left + 1; i <= right; i++) {
-        const node = arr[i], z = node.z;
-        let j = i - 1;
-        while (j >= left && arr[j].z > z) { arr[j + 1] = arr[j]; j--; }
-        arr[j + 1] = node;
+
+    if (zArr.length < n) {
+        zArr = new Uint32Array(n);
+        zBuf = new Uint32Array(n);
+        sortBuf = new Array(n);
+    }
+    for (let i = 0; i < n; i++) zArr[i] = sortArr[i].z;
+
+    // even pass count lands the sorted result back in sortArr
+    radixPass(n, sortArr, zArr, sortBuf, zBuf, 0);
+    radixPass(n, sortBuf, zBuf, sortArr, zArr, 8);
+    radixPass(n, sortArr, zArr, sortBuf, zBuf, 16);
+    radixPass(n, sortBuf, zBuf, sortArr, zArr, 24);
+}
+
+// one LSD radix pass: stably scatter the first n nodes (and their z) from src to dst,
+// bucketed by the 8-bit digit of z at the given bit shift
+/** @param {number} n @param {Node[]} src @param {Uint32Array} srcZ @param {Node[]} dst @param {Uint32Array} dstZ @param {number} shift */
+function radixPass(n, src, srcZ, dst, dstZ, shift) {
+    counts.fill(0);
+    for (let i = 0; i < n; i++) counts[(srcZ[i] >>> shift) & 0xff]++;
+    // turn per-bucket counts into start offsets (prefix sum)
+    let sum = 0;
+    for (let b = 0; b < 256; b++) { const c = counts[b]; counts[b] = sum; sum += c; }
+    for (let i = 0; i < n; i++) {
+        const z = srcZ[i];
+        const pos = counts[(z >>> shift) & 0xff]++;
+        dst[pos] = src[i];
+        dstZ[pos] = z;
     }
 }
 


### PR DESCRIPTION
Overall a ~6% improvement on the 120k MVT polygons benchmark.

- **Radix sort for z-order hashing** — replaced the recursive quicksort used to z-index polygon nodes with an in-place LSD radix sort (four 8-bit passes over the 30-bit z values, with parallel typed `z` arrays for contiguous reads and insertion sort for small rings).
- **Better filtering for pathological cases** — the stall handler now repeatedly filters out collinear/coincident points as long as each pass keeps making progress, exposing new ears before falling through to the costlier local-intersection-curing and splitting stages.
- Slightly faster `isValidDiagonal` (cheap checks first)
- Simplified `earcutLinked` control flow
- Simplified the `isEar` / `isEarHashed` checks